### PR TITLE
Simpler multi-step UI

### DIFF
--- a/public/dashboard.html
+++ b/public/dashboard.html
@@ -1,0 +1,59 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="UTF-8">
+  <title>Dashboard - AI Gym Assistant</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <nav>
+    <a href="index.html">Home</a>
+    <a href="signup.html">Sign Up</a>
+    <a href="login.html">Login</a>
+  </nav>
+  <h1>Dashboard</h1>
+  <h2>Workouts</h2>
+  <button id="getWorkouts">Load Workouts</button>
+  <ul id="workoutList"></ul>
+  <h3>Log Workout</h3>
+  <form id="logForm">
+    <input type="email" id="logEmail" placeholder="Email" required>
+    <input type="number" id="logWorkoutId" placeholder="Workout ID" required>
+    <button type="submit">Log</button>
+  </form>
+  <h3>AI Generated Workout</h3>
+  <form id="aiForm">
+    <input type="email" id="aiEmail" placeholder="Email" required>
+    <button type="submit">Get Plan</button>
+  </form>
+  <h3>Send Feedback</h3>
+  <form id="feedbackForm">
+    <input type="email" id="fbEmail" placeholder="Email" required>
+    <input type="text" id="fbText" placeholder="Your feedback" required>
+    <button type="submit">Send</button>
+  </form>
+  <h3>Voice Command</h3>
+  <form id="voiceForm">
+    <input type="email" id="voiceEmail" placeholder="Email" required>
+    <input type="text" id="voiceText" placeholder="Speech text" required>
+    <button type="submit">Send Voice</button>
+  </form>
+  <h3>Wearable Data</h3>
+  <form id="wearableForm">
+    <input type="email" id="wearEmail" placeholder="Email" required>
+    <input type="number" id="wearSteps" placeholder="Steps">
+    <input type="number" id="wearHR" placeholder="Heart Rate">
+    <button type="submit">Submit Data</button>
+  </form>
+  <h3>Tutorial Videos</h3>
+  <button id="loadTutorials">Load Videos</button>
+  <ul id="tutorialList"></ul>
+  <h3>Share Progress</h3>
+  <form id="shareForm">
+    <input type="email" id="shareEmail" placeholder="Email" required>
+    <button type="submit">Share</button>
+  </form>
+  <pre id="output"></pre>
+  <script src="dashboard.js"></script>
+</body>
+</html>

--- a/public/dashboard.js
+++ b/public/dashboard.js
@@ -1,0 +1,60 @@
+async function request(url, data) {
+  const res = await fetch(url, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(data)
+  });
+  return res.json();
+}
+
+document.getElementById('getWorkouts').addEventListener('click', async () => {
+  const res = await fetch('/workouts');
+  const data = await res.json();
+  workoutList.innerHTML = data.map(w => `<li>${w.id}: ${w.name} - ${w.sets}x${w.reps}</li>`).join('');
+});
+
+document.getElementById('logForm').addEventListener('submit', async e => {
+  e.preventDefault();
+  const data = { email: logEmail.value, workoutId: logWorkoutId.value };
+  const out = await request('/log', data);
+  output.textContent = JSON.stringify(out, null, 2);
+});
+
+document.getElementById('aiForm').addEventListener('submit', async e => {
+  e.preventDefault();
+  const out = await request('/ai-workout', { email: aiEmail.value });
+  output.textContent = out.workout;
+});
+
+document.getElementById('feedbackForm').addEventListener('submit', async e => {
+  e.preventDefault();
+  const data = { email: fbEmail.value, feedback: fbText.value };
+  const out = await request('/feedback', data);
+  output.textContent = JSON.stringify(out, null, 2);
+});
+
+document.getElementById('voiceForm').addEventListener('submit', async e => {
+  e.preventDefault();
+  const data = { email: voiceEmail.value, transcript: voiceText.value };
+  const out = await request('/voice', data);
+  output.textContent = JSON.stringify(out, null, 2);
+});
+
+document.getElementById('wearableForm').addEventListener('submit', async e => {
+  e.preventDefault();
+  const data = { email: wearEmail.value, steps: wearSteps.value, heart_rate: wearHR.value };
+  const out = await request('/wearable', data);
+  output.textContent = JSON.stringify(out, null, 2);
+});
+
+document.getElementById('loadTutorials').addEventListener('click', async () => {
+  const res = await fetch('/tutorials');
+  const vids = await res.json();
+  tutorialList.innerHTML = vids.map(v => `<li><a href="${v}">${v}</a></li>`).join('');
+});
+
+document.getElementById('shareForm').addEventListener('submit', async e => {
+  e.preventDefault();
+  const out = await request('/share', { email: shareEmail.value });
+  output.textContent = JSON.stringify(out, null, 2);
+});

--- a/public/index.html
+++ b/public/index.html
@@ -2,142 +2,16 @@
 <html>
 <head>
   <meta charset="UTF-8">
-  <title>AI Gym Assistant - Stage 4</title>
+  <title>AI Gym Assistant</title>
+  <link rel="stylesheet" href="style.css">
 </head>
 <body>
-  <h1>Welcome to AI Gym Assistant</h1>
-  <p>Stage 4: Wearable integration and social sharing.</p>
-  <h2>Sign Up</h2>
-  <form id="signupForm">
-    <input type="email" id="signupEmail" placeholder="Email" required>
-    <input type="password" id="signupPassword" placeholder="Password" required>
-    <input type="number" id="signupAge" placeholder="Age">
-    <input type="number" id="signupWeight" placeholder="Weight (kg)">
-    <input type="text" id="signupGoals" placeholder="Goals">
-    <button type="submit">Sign Up</button>
-  </form>
-  <h2>Login</h2>
-  <form id="loginForm">
-    <input type="email" id="loginEmail" placeholder="Email" required>
-    <input type="password" id="loginPassword" placeholder="Password" required>
-    <button type="submit">Login</button>
-  </form>
-  <h2>Workouts</h2>
-  <button id="getWorkouts">Load Workouts</button>
-  <ul id="workoutList"></ul>
-  <h3>Log Workout</h3>
-  <form id="logForm">
-    <input type="email" id="logEmail" placeholder="Email" required>
-    <input type="number" id="logWorkoutId" placeholder="Workout ID" required>
-    <button type="submit">Log</button>
-  </form>
-  <h3>AI Generated Workout</h3>
-  <form id="aiForm">
-    <input type="email" id="aiEmail" placeholder="Email" required>
-    <button type="submit">Get Plan</button>
-  </form>
-  <h3>Send Feedback</h3>
-  <form id="feedbackForm">
-    <input type="email" id="fbEmail" placeholder="Email" required>
-    <input type="text" id="fbText" placeholder="Your feedback" required>
-    <button type="submit">Send</button>
-  </form>
-  <h3>Voice Command</h3>
-  <form id="voiceForm">
-    <input type="email" id="voiceEmail" placeholder="Email" required>
-    <input type="text" id="voiceText" placeholder="Speech text" required>
-    <button type="submit">Send Voice</button>
-  </form>
-  <h3>Wearable Data</h3>
-  <form id="wearableForm">
-    <input type="email" id="wearEmail" placeholder="Email" required>
-    <input type="number" id="wearSteps" placeholder="Steps">
-    <input type="number" id="wearHR" placeholder="Heart Rate">
-    <button type="submit">Submit Data</button>
-  </form>
-  <h3>Tutorial Videos</h3>
-  <button id="loadTutorials">Load Videos</button>
-  <ul id="tutorialList"></ul>
-  <h3>Share Progress</h3>
-  <form id="shareForm">
-    <input type="email" id="shareEmail" placeholder="Email" required>
-    <button type="submit">Share</button>
-  </form>
-  <pre id="output"></pre>
-  <script>
-    async function request(url, data) {
-      const res = await fetch(url, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify(data)
-      });
-      return res.json();
-    }
-    document.getElementById('signupForm').addEventListener('submit', async (e) => {
-      e.preventDefault();
-      const data = {
-        email: signupEmail.value,
-        password: signupPassword.value,
-        age: signupAge.value,
-        weight: signupWeight.value,
-        goals: signupGoals.value
-      };
-      const out = await request('/signup', data);
-      output.textContent = JSON.stringify(out, null, 2);
-    });
-    document.getElementById('loginForm').addEventListener('submit', async (e) => {
-      e.preventDefault();
-      const data = {
-        email: loginEmail.value,
-        password: loginPassword.value
-      };
-      const out = await request('/login', data);
-      output.textContent = JSON.stringify(out, null, 2);
-    });
-    document.getElementById('getWorkouts').addEventListener('click', async () => {
-      const res = await fetch('/workouts');
-      const data = await res.json();
-      workoutList.innerHTML = data.map(w => `<li>${w.id}: ${w.name} - ${w.sets}x${w.reps}</li>`).join('');
-    });
-    document.getElementById('logForm').addEventListener('submit', async (e) => {
-      e.preventDefault();
-      const data = { email: logEmail.value, workoutId: logWorkoutId.value };
-      const out = await request('/log', data);
-      output.textContent = JSON.stringify(out, null, 2);
-    });
-    document.getElementById('aiForm').addEventListener('submit', async (e) => {
-      e.preventDefault();
-      const out = await request('/ai-workout', { email: aiEmail.value });
-      output.textContent = out.workout;
-    });
-    document.getElementById('feedbackForm').addEventListener('submit', async (e) => {
-      e.preventDefault();
-      const data = { email: fbEmail.value, feedback: fbText.value };
-      const out = await request('/feedback', data);
-      output.textContent = JSON.stringify(out, null, 2);
-    });
-    document.getElementById('voiceForm').addEventListener('submit', async (e) => {
-      e.preventDefault();
-      const data = { email: voiceEmail.value, transcript: voiceText.value };
-      const out = await request('/voice', data);
-      output.textContent = JSON.stringify(out, null, 2);
-    });
-    document.getElementById('wearableForm').addEventListener('submit', async (e) => {
-      e.preventDefault();
-      const data = { email: wearEmail.value, steps: wearSteps.value, heart_rate: wearHR.value };
-      const out = await request('/wearable', data);
-      output.textContent = JSON.stringify(out, null, 2);
-    });
-    document.getElementById('loadTutorials').addEventListener('click', async () => {
-      const res = await fetch('/tutorials');
-      const vids = await res.json();
-      tutorialList.innerHTML = vids.map(v => `<li><a href="${v}">${v}</a></li>`).join('');
-    });
-    document.getElementById('shareForm').addEventListener('submit', async (e) => {
-      e.preventDefault();
-      const out = await request('/share', { email: shareEmail.value });
-      output.textContent = JSON.stringify(out, null, 2);
-    });
-  </script>
+  <h1>AI Gym Assistant</h1>
+  <nav>
+    <a href="signup.html">Sign Up</a>
+    <a href="login.html">Login</a>
+    <a href="dashboard.html">Dashboard</a>
+  </nav>
+  <p>Your personal training companion.</p>
 </body>
 </html>

--- a/public/login.html
+++ b/public/login.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="UTF-8">
+  <title>Login - AI Gym Assistant</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <nav>
+    <a href="index.html">Home</a>
+    <a href="signup.html">Sign Up</a>
+    <a href="dashboard.html">Dashboard</a>
+  </nav>
+  <h2>Login</h2>
+  <form id="loginForm">
+    <input type="email" id="loginEmail" placeholder="Email" required>
+    <input type="password" id="loginPassword" placeholder="Password" required>
+    <button type="submit">Login</button>
+  </form>
+  <pre id="output"></pre>
+  <script src="login.js"></script>
+</body>
+</html>

--- a/public/login.js
+++ b/public/login.js
@@ -1,0 +1,18 @@
+async function request(url, data) {
+  const res = await fetch(url, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(data)
+  });
+  return res.json();
+}
+
+document.getElementById('loginForm').addEventListener('submit', async e => {
+  e.preventDefault();
+  const data = {
+    email: loginEmail.value,
+    password: loginPassword.value
+  };
+  const out = await request('/login', data);
+  output.textContent = JSON.stringify(out, null, 2);
+});

--- a/public/signup.html
+++ b/public/signup.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="UTF-8">
+  <title>Sign Up - AI Gym Assistant</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <nav>
+    <a href="index.html">Home</a>
+    <a href="login.html">Login</a>
+    <a href="dashboard.html">Dashboard</a>
+  </nav>
+  <h2>Sign Up</h2>
+  <form id="signupForm">
+    <input type="email" id="signupEmail" placeholder="Email" required>
+    <input type="password" id="signupPassword" placeholder="Password" required>
+    <input type="number" id="signupAge" placeholder="Age">
+    <input type="number" id="signupWeight" placeholder="Weight (kg)">
+    <input type="text" id="signupGoals" placeholder="Goals">
+    <button type="submit">Sign Up</button>
+  </form>
+  <pre id="output"></pre>
+  <script src="signup.js"></script>
+</body>
+</html>

--- a/public/signup.js
+++ b/public/signup.js
@@ -1,0 +1,21 @@
+async function request(url, data) {
+  const res = await fetch(url, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(data)
+  });
+  return res.json();
+}
+
+document.getElementById('signupForm').addEventListener('submit', async e => {
+  e.preventDefault();
+  const data = {
+    email: signupEmail.value,
+    password: signupPassword.value,
+    age: signupAge.value,
+    weight: signupWeight.value,
+    goals: signupGoals.value
+  };
+  const out = await request('/signup', data);
+  output.textContent = JSON.stringify(out, null, 2);
+});

--- a/public/style.css
+++ b/public/style.css
@@ -1,0 +1,17 @@
+body {
+  font-family: Arial, sans-serif;
+  max-width: 600px;
+  margin: auto;
+  padding: 1rem;
+  line-height: 1.5;
+}
+nav a {
+  margin-right: 1rem;
+}
+form {
+  margin-bottom: 1rem;
+}
+input, button {
+  padding: 0.5rem;
+  margin: 0.25rem 0;
+}


### PR DESCRIPTION
## Summary
- restructure public pages into a small multi-page UI
- add dedicated signup, login and dashboard pages
- extract client-side logic into small js files
- provide basic styling

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6847d6c8112883289aa906b465610f39